### PR TITLE
website: Fix broken links for dual-booting with windows

### DIFF
--- a/website/docs/software/ubuntu/index.mdx
+++ b/website/docs/software/ubuntu/index.mdx
@@ -45,7 +45,7 @@ Choose your OS below for USB creation instructions:
 4. Click **Start** and wait for the write to finish
 :::tip
 If you would like to keep your operating system:
-[See Dual Boot Instructions →](#dual-booting-with-windows)
+[See Dual Boot Instructions →](dual_boot)
 :::
 
 ### On macOS (Etcher or Terminal)
@@ -100,7 +100,7 @@ Once the installer loads:
 2. Select "Erase disk and install Ubuntu" (for a clean install)
 :::warning
 This will erase all data on the selected drive.
-If you would like to keep your operating system: [See Dual Boot Instructions](#dual-booting-with-windows)
+If you would like to keep your operating system: [See Dual Boot Instructions](dual_boot)
 :::
 3. Choose your timezone
 4. Create a username and password


### PR DESCRIPTION
Fix the following warning:

    Exhaustive list of all broken anchors found:
    - Broken anchor on source page path = /software/ubuntu/:
       -> linking to #dual-booting-with-windows (resolved as: /software/ubuntu/#dual-booting-with-windows)

Places:

https://docs.openarm.dev/software/ubuntu/#on-windows-rufus
https://docs.openarm.dev/software/ubuntu/#install-ubuntu
