### PR TITLE
Remove ros2_package submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "simulation"]
 	path = simulation
 	url = https://github.com/enactic/openarm_simulation.git
-[submodule "ros2_packages"]
-	path = ros2_packages
-	url = https://github.com/enactic/openarm_ros2.git


### PR DESCRIPTION
We use this repository only for website and OpenArm global issue management.

Please use https://github.com/enactic/openarm_ros2.git directly.