### PR TITLE
Fix type errors

### DIFF
--- a/website/src/components/ArmManufacturedTable.tsx
+++ b/website/src/components/ArmManufacturedTable.tsx
@@ -15,15 +15,10 @@
 import React, {
   type ReactNode
 } from 'react';
-import BoMTable, { type BoMTableColumn } from './BoMTable';
+import BoMTable, { type BoMRecord, type BoMTableColumn } from './BoMTable';
 import { calculateTotalCost } from '../utils/priceUtils';
 
-export interface ArmManufacturedComponent {
-  name: string;
-  image: string;
-  model: string;
-  quantity: number;
-  unitPrice: number;
+export interface ArmManufacturedComponent extends BoMRecord {
   method: string;
   material: string;
   manufacturer: string;

--- a/website/src/components/ArmOffTheShelfTable.tsx
+++ b/website/src/components/ArmOffTheShelfTable.tsx
@@ -15,15 +15,10 @@
 import React, {
   type ReactNode
 } from 'react';
-import BoMTable, { type BoMTableColumn } from './BoMTable';
+import BoMTable, { type BoMRecord, type BoMTableColumn } from './BoMTable';
 import { calculateTotalCost } from '../utils/priceUtils';
 
-export interface ArmOffTheShelfComponent {
-  name: string;
-  image: string;
-  model: string;
-  quantity: number;
-  unitPrice: number;
+export interface ArmOffTheShelfComponent extends BoMRecord {
   supplier: string;
 }
 

--- a/website/src/components/BoMTable.tsx
+++ b/website/src/components/BoMTable.tsx
@@ -19,6 +19,14 @@ import Admonition from '@theme/Admonition';
 import BoMPhoto from './BoMPhoto';
 import { formatPrice, formatTotalCost } from '../utils/priceUtils';
 
+export interface BoMRecord {
+  name: string;
+  image: string;
+  model: string | ReactNode;
+  quantity: number;
+  unitPrice: number;
+}
+
 export interface BoMTableColumn<T> {
   header: string;
   key: keyof T | 'totalPrice';
@@ -64,7 +72,7 @@ const tableStyles = {
 
 export { tableStyles };
 
-export default function BoMTable<T extends Record<string, any>>({
+export default function BoMTable<T extends BoMRecord>({
   type,
   components,
   columns,
@@ -83,13 +91,13 @@ export default function BoMTable<T extends Record<string, any>>({
     }
   };
 
-  const renderCell = (component: T, column: BoMTableColumn<T>) => {
+  const renderCell = (component: T, column: BoMTableColumn<T>): ReactNode => {
     switch (column.key) {
       case 'image':
         return component.image ? (
           <BoMPhoto
             src={require(`@site/static/img/hardware/bom/${imageBasePath}/${component.image}`).default}
-            alt={component.name || component.model || ''}
+            alt={component.name || ''}
           />
         ) : null;
       case 'unitPrice':
@@ -97,7 +105,7 @@ export default function BoMTable<T extends Record<string, any>>({
       case 'totalPrice':
         return <strong>{formatPrice(component.unitPrice * component.quantity)}</strong>;
       default:
-        return component[column.key as keyof T];
+        return component[column.key as keyof T] as ReactNode;
     }
   };
 

--- a/website/src/components/ElectricalTable.tsx
+++ b/website/src/components/ElectricalTable.tsx
@@ -15,15 +15,10 @@
 import React, {
   type ReactNode
 } from 'react';
-import BoMTable, { type BoMTableColumn } from './BoMTable';
+import BoMTable, { type BoMRecord, type BoMTableColumn } from './BoMTable';
 import { calculateTotalCost } from '../utils/priceUtils';
 
-export interface ElectricalComponent {
-  name: string;
-  image: string;
-  model: ReactNode;
-  quantity: number;
-  unitPrice: number;
+export interface ElectricalComponent extends BoMRecord {
   supplier: string;
 }
 

--- a/website/src/components/GripperManufacturedTable.tsx
+++ b/website/src/components/GripperManufacturedTable.tsx
@@ -15,15 +15,10 @@
 import React, {
   type ReactNode
 } from 'react';
-import BoMTable, { type BoMTableColumn } from './BoMTable';
+import BoMTable, { type BoMRecord, type BoMTableColumn } from './BoMTable';
 import { calculateTotalCost } from '../utils/priceUtils';
 
-export interface GripperManufacturedComponent {
-  name: string;
-  image: string;
-  model: string;
-  quantity: number;
-  unitPrice: number;
+export interface GripperManufacturedComponent extends BoMRecord {
   method: string;
   material: string;
   manufacturer: string;

--- a/website/src/components/GripperOffTheShelfTable.tsx
+++ b/website/src/components/GripperOffTheShelfTable.tsx
@@ -28,12 +28,12 @@ export interface GripperOffTheShelfComponent {
 }
 
 const components: GripperOffTheShelfComponent[] = [
-  { name: 'Miniature Linear Guide Standard Block', image: 'rse2b10-155.png', model: 'RSE2B10-155', quantity: 2, unitPrice: '14940', supplier: 'MiSUMi'},
-  { name: 'M3x5 bolt', image: 'm3-5.png', model: 'CBE3-5', quantity: 8, unitPrice: '70', supplier: 'MiSUMi'},
-  { name: 'M3x8 bolt', image: 'm3-8.png', model: 'CBE3-8', quantity: 20, unitPrice: '56', supplier: 'MiSUMi'},
-  { name: 'Small Diameter Head bolts M3x6', image: 'kbbs3-6.png', model: 'KBBS3-6', quantity: 32, unitPrice: '228', supplier: 'MiSUMi'},
-  { name: 'Step Bolt', image: 'dbsy4-5-4.png', model: 'DBSY4-5-4', quantity: 8, unitPrice: '440', supplier: 'MiSUMi'},
-  { name: 'Bearing', image: 'mr126zz.png', model: 'MR126ZZ', quantity: 8, unitPrice: '482', supplier: 'MiSUMi'},
+  { name: 'Miniature Linear Guide Standard Block', image: 'rse2b10-155.png', model: 'RSE2B10-155', quantity: 2, unitPrice: 14940, supplier: 'MiSUMi'},
+  { name: 'M3x5 bolt', image: 'm3-5.png', model: 'CBE3-5', quantity: 8, unitPrice: 70, supplier: 'MiSUMi'},
+  { name: 'M3x8 bolt', image: 'm3-8.png', model: 'CBE3-8', quantity: 20, unitPrice: 56, supplier: 'MiSUMi'},
+  { name: 'Small Diameter Head bolts M3x6', image: 'kbbs3-6.png', model: 'KBBS3-6', quantity: 32, unitPrice: 228, supplier: 'MiSUMi'},
+  { name: 'Step Bolt', image: 'dbsy4-5-4.png', model: 'DBSY4-5-4', quantity: 8, unitPrice: 440, supplier: 'MiSUMi'},
+  { name: 'Bearing', image: 'mr126zz.png', model: 'MR126ZZ', quantity: 8, unitPrice: 482, supplier: 'MiSUMi'},
 ];
 
 const columns: BoMTableColumn<GripperOffTheShelfComponent>[] = [

--- a/website/src/components/PedestalManufacturedTable.tsx
+++ b/website/src/components/PedestalManufacturedTable.tsx
@@ -15,15 +15,10 @@
 import React, {
   type ReactNode
 } from 'react';
-import BoMTable, { type BoMTableColumn } from './BoMTable';
+import BoMTable, { type BoMRecord, type BoMTableColumn } from './BoMTable';
 import { calculateTotalCost } from '../utils/priceUtils';
 
-export interface PedestalManufacturedComponent {
-  name: string;
-  image: string;
-  model: string;
-  quantity: number;
-  unitPrice: number;
+export interface PedestalManufacturedComponent extends BoMRecord {
   method: string;
   material: string;
   manufacturer: string;

--- a/website/src/components/PedestalOffTheShelfTable.tsx
+++ b/website/src/components/PedestalOffTheShelfTable.tsx
@@ -15,15 +15,10 @@
 import React, {
   type ReactNode
 } from 'react';
-import BoMTable, { type BoMTableColumn } from './BoMTable';
+import BoMTable, { type BoMRecord, type BoMTableColumn } from './BoMTable';
 import { calculateTotalCost } from '../utils/priceUtils';
 
-export interface PedestalOffTheShelfComponent {
-  name: string;
-  image: string;
-  model: string;
-  quantity: number;
-  unitPrice: number;
+export interface PedestalOffTheShelfComponent extends BoMRecord {
   supplier: string;
 }
 


### PR DESCRIPTION
The follwoing type error is raised when we execite `npm run typecheck` command.

```console
$ npm run typecheck

> openarm-site@0.0.0 typecheck
> tsc

src/components/BoMTable.tsx:73:37 - error TS2345: Argument of type 'T[]' is not assignable to parameter of type '{ unitPrice: number; quantity: number; }[]'.
  Type 'T' is not assignable to type '{ unitPrice: number; quantity: number; }'.
    Type 'Record<string, any>' is missing the following properties from type '{ unitPrice: number; quantity: number; }': unitPrice, quantity

73   const totalCost = formatTotalCost(components);
                                       ~~~~~~~~~~
```

We added the BoMRecord type to define the necessary attributes for BoMTable.