### PR TITLE
Fix CSV file loading by using require() consistently for all local files

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -79,6 +79,10 @@ const config: Config = {
     ],
   ],
 
+  plugins: [
+    './src/plugins/csv-loader/index.ts',
+  ],
+
   themeConfig: {
     // Replace with your project's social card
     image: 'img/social-card.svg',

--- a/website/src/components/ElectricalTable.tsx
+++ b/website/src/components/ElectricalTable.tsx
@@ -29,10 +29,7 @@ interface ModelProps {
 
 function Model({ href, label }: ModelProps) : ReactNode {
   if (!href.startsWith('http')) {
-    // TODO: This doesn't work for .csv but we want to use require() to detect
-    // broken links.
-    // href = require(`/file/hardware/bill-of-materials/electrical/${href}`).default;
-    href = `/file/hardware/bill-of-materials/electrical/${href}`;
+    href = require(`@site/static/file/hardware/bill-of-materials/electrical/${href}`).default;
   }
   return (
     <a

--- a/website/src/plugins/csv-loader/index.ts
+++ b/website/src/plugins/csv-loader/index.ts
@@ -1,0 +1,35 @@
+// Copyright 2025 Enactic, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Plugin } from '@docusaurus/types';
+
+const csvLoader = (): Plugin => {
+  return {
+    name: 'csv-loader-plugin',
+    configureWebpack() {
+      return {
+        module: {
+          rules: [
+            {
+              test: /\.csv$/,
+              use: 'file-loader',
+            },
+          ],
+        },
+      };
+    },
+  };
+};
+
+export default csvLoader;

--- a/website/src/plugins/csv-loader/index.ts
+++ b/website/src/plugins/csv-loader/index.ts
@@ -14,7 +14,7 @@
 
 import type { Plugin } from '@docusaurus/types';
 
-const csvLoader = (): Plugin => {
+export default function csvLoader(): Plugin {
   return {
     name: 'csv-loader-plugin',
     configureWebpack() {
@@ -31,5 +31,3 @@ const csvLoader = (): Plugin => {
     },
   };
 };
-
-export default csvLoader;


### PR DESCRIPTION
## Problem

CSV files were causing webpack parse errors when loaded directly through href paths, showing
"Unexpected character" errors for binary files.

```
npm run start

> openarm-site@0.0.0 start
> docusaurus start

[INFO] Starting the development server...
[SUCCESS] Docusaurus website is running at: http://localhost:3000/

✖ Client
  Compiled with some errors in 5.07s

Module parse failed: Unexpected character '�' (1:0)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
(Source code omitted for this binary file)
client (webpack 5.99.9) compiled with 1 error
```

## Cause

The Model component was inconsistently handling file paths - using require() for the href assignment but then passing the processed href directly to the <a> tag, causing webpack to try parsing binary files as modules.

## Solution

Updated Model component to use require().default
consistently for all local files, ensuring webpack treats CSV files as static assets rather than trying to parse them as JavaScript modules.