### PR TITLE
website: Use robots.txt to verify domain by Algoria

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -86,9 +86,6 @@ const config: Config = {
   themeConfig: {
     // Replace with your project's social card
     image: 'img/social-card.svg',
-    metadata: [
-      {name: 'algolia-site-verification', content: 'F06502A35B61FF7C'},
-    ],
     navbar: {
       title: 'OpenArm',
       logo: {

--- a/website/static/robots.txt
+++ b/website/static/robots.txt
@@ -1,0 +1,15 @@
+# Copyright 2025 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Algolia-Crawler-Verif: F06502A35B61FF7C


### PR DESCRIPTION
It seems that the Algoria's domain verify program doesn't evaluate JavaScript.