### PR TITLE
Fix software doc typos

### DIFF
--- a/website/docs/software/description.mdx
+++ b/website/docs/software/description.mdx
@@ -198,18 +198,18 @@ Below are some configurable variables for the OpenArm robot description that all
 
 ### Running Multiple Robots with ROS Namespaces and ROS_DOMAIN_ID
 
-When running multiple instances of OpenArm, one option is to namespace arms to control multiple sets of arms with one device. 
+When running multiple instances of OpenArm, one option is to namespace arms to control multiple sets of arms with one device.
 
 For example, when running multiple instances of bimanual, it is possible to namespace packages with:
 
 ```sh
-ros2 launch openarm.bimanual.launch.py arm_prefix:=leader right_can_interface:=can0 left_can_interface:=can1
+ros2 launch openarm_description openarm.bimanual.launch.py arm_prefix:=leader right_can_interface:=can0 left_can_interface:=can1
 ```
 
 and
 
 ```sh
-ros2 launch openarm.bimanual.launch.py arm_prefix:=follower right_can_interface:=can2 left_can_interface:=can3
+ros2 launch openarm_description openarm.bimanual.launch.py arm_prefix:=follower right_can_interface:=can2 left_can_interface:=can3
 ```
 
 If network isolation is required (e.g. multiple sets of OpenArm teleoperation), the [ROS_DOMAIN_ID](https://docs.ros.org/en/humble/Concepts/Intermediate/About-Domain-ID.html) environment variable can be set.

--- a/website/docs/software/setup/5-motor-config.mdx
+++ b/website/docs/software/setup/5-motor-config.mdx
@@ -75,7 +75,7 @@ Set the zero position for a specific motor:
 
 Or set zero position for all motors (IDs 001-008):
 ```bash
-./set_zero.sh can0 -all
+./set_zero.sh can0 --all
 ```
 
 :::tip


### PR DESCRIPTION
- reflect the typo fix in https://github.com/enactic/openarm_can/pull/26
- add missing package names in ros2 launch commands