### PR TITLE
Remove deprecated config onBrokenMarkdownLinks

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -40,7 +40,6 @@ const config: Config = {
   projectName: 'openarm', // Usually your repo name.
 
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you


### PR DESCRIPTION
`siteConfig.onBrokenMarkdownLinks` is deprecated:

    [WARNING] The `siteConfig.onBrokenMarkdownLinks` config option is deprecated and will be removed in Docusaurus v4.
    Please migrate and move this option to `siteConfig.markdown.hooks.onBrokenMarkdownLinks` instead.

In the beginning, the default value is `warn`, so we don't need to set this option.

https://docusaurus.io/docs/api/docusaurus-config#hooks.onBrokenMarkdownLinks

Note: If we set this option explicitly, we can as following:

    markdown: {
      hooks: {
        onBrokenMarkdownLinks: 'warn',
      },
    },