### PR TITLE
ci: use group to update docusaurus

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,8 @@ updates:
     commit-message:
       prefix: "website: "
     open-pull-requests-limit: 10
+    groups:
+      # All official @docusaurus/* packages should have the exact same version
+      docusaurus:
+        patterns:
+          - "@docusaurus/*"


### PR DESCRIPTION
We need to update all `@docusaurus/*` dependencies together in a single PR.
Otherwise, the following error occurs:

    [ERROR] Error: Unable to build website for locale en.
      ...
      [cause]: Error: ...
      All official @docusaurus/* packages should have the exact same version
      ...