### PR TITLE
ros2 install: Add ROS 2 MoveIt2 installation package

### DIFF
--- a/website/docs/software/ros2/install.mdx
+++ b/website/docs/software/ros2/install.mdx
@@ -45,6 +45,7 @@ sudo apt install -y \
 # You must also install the following packages when using MoveIt2.
 sudo apt install -y \
   ros-humble-moveit-configs-utils \
+  ros-humble-moveit-planners \
   ros-humble-moveit-ros-move-group \
   ros-humble-moveit-ros-visualization
 ```


### PR DESCRIPTION
Since it was missing, we're adding it.

This confirmed that the display and behavior are same as in the document.
https://docs.openarm.dev/software/ros2/control#motion-planning