### PR TITLE
fix: resolve deprecated baseUrl warning for TypeScript 6.0

### DIFF
--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -16,7 +16,12 @@
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
-    "baseUrl": ".",
+    // TODO: Remove baseUrl and paths overrides when Docusaurus v4 drops baseUrl.
+    // See: https://github.com/facebook/docusaurus/pull/11843#issuecomment-4134659968
+    "baseUrl": null,
+    "paths": {
+      "@site/*": ["./*"]
+    },
   },
   "exclude": [".docusaurus", "build"],
 }


### PR DESCRIPTION
GitHub: ref GH-439

Override inherited baseUrl with null and re-declare paths to avoid the TS6 deprecation from @docusaurus/tsconfig, without using ignoreDeprecations.

```console
$ npm run typecheck
> openarm-site@0.0.0 typecheck
> tsc

Error: tsconfig.json(19,5): error TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
  Visit https://aka.ms/ts6 for migration information.
Error: Process completed with exit code 2.
```