### PR TITLE
fix: resolve type errors in `TableColumn` `render` callbacks

### DIFF
--- a/website/src/components/Table.tsx
+++ b/website/src/components/Table.tsx
@@ -14,11 +14,13 @@
 
 import React, { type ReactNode } from 'react';
 
-export interface TableColumn<T> {
-  header: string;
-  key: keyof T;
-  render?: (row: T, value: T[keyof T]) => ReactNode;
-}
+export type TableColumn<T> = {
+  [K in keyof T]: {
+    header: string;
+    key: K;
+    render?: (row: T, value: T[K]) => ReactNode;
+  };
+}[keyof T];
 
 interface TableProps<T> {
   columns: TableColumn<T>[];


### PR DESCRIPTION
GitHub: ref GH-439

The `value` parameter in `TableColumn<T>`'s `render` was typed as `T[keyof T]`, which resolves to the union of all field types (e.g. `string | number`). This caused type errors when individual columns narrowed `value` to `string` or `number`:

```console
$ npm run typecheck
...
src/components/ActuatorsTable.tsx:65:5 - error TS2322: Type '(row: ActuatorRecord, value: string) => Element' is not assignable to type '(row: ActuatorRecord, value: string | number) => ReactNode'.
  Types of parameters 'value' and 'value' are incompatible.
    Type 'string | number' is not assignable to type 'string'.
      Type 'number' is not assignable to type 'string'.

65     render: (row, value: string) => <em>{value}</em>
       ~~~~~~

  src/components/Table.tsx:20:3
    20   render?: (row: T, value: T[keyof T]) => ReactNode;
         ~~~~~~
    The expected type comes from property 'render' which is declared here on type 'TableColumn<ActuatorRecord>'
...
```

Use a mapped type with indexed access so that each column's `key` is linked to its `render` callback's `value` type, allowing each column to receive the correct field type.