### PR TITLE
website: Rename demo title in Isaac Lab page

### DIFF
--- a/website/docs/simulation/isaac-lab.mdx
+++ b/website/docs/simulation/isaac-lab.mdx
@@ -41,7 +41,7 @@ Currently, four reinforcement learning–based environments using OpenArm are pu
 
 <BlockVideo src="simulation/isaac-lab/opening-drawer.mp4" width="65%"/>
 
-* **Opening a Drawer**
+* **OpenArm Reaching**
 
 <BlockVideo src="simulation/isaac-lab/openarm-bi-reach-demo.mp4" width="65%"/>
 

--- a/website/versioned_docs/version-1.0/simulation/isaac-lab.mdx
+++ b/website/versioned_docs/version-1.0/simulation/isaac-lab.mdx
@@ -41,7 +41,7 @@ Currently, four reinforcement learning–based environments using OpenArm are pu
 
 <BlockVideo src="simulation/isaac-lab/opening-drawer.mp4" width="65%"/>
 
-* **Opening a Drawer**
+* **OpenArm Reaching**
 
 <BlockVideo src="simulation/isaac-lab/openarm-bi-reach-demo.mp4" width="65%"/>
 


### PR DESCRIPTION
The fourth entry labeled "Opening a Drawer" duplicated the third entry, but the linked video shows OpenArm reaching.
Rename it to "OpenArm Reaching".

Fix this:
https://github.com/enactic/openarm/pull/455#discussion_r3097582868