### PR TITLE
website: Fix wrong default CAN interface mapping

### DIFF
--- a/website/docs/teleop/leader-follower/bilateral-control.md
+++ b/website/docs/teleop/leader-follower/bilateral-control.md
@@ -62,8 +62,8 @@ cd openarm_teleop
 
 If the CAN interfaces are omitted, the script uses the following defaults:
 
-- For `right_arm`: leader = `can0`, follower = `can1`
-- For `left_arm`: leader = `can2`, follower = `can3`
+- For `right_arm`: leader = `can0`, follower = `can2`
+- For `left_arm`: leader = `can1`, follower = `can3`
 
 ### What the Script Does
 

--- a/website/versioned_docs/version-1.0/teleop/leader-follower/bilateral-control.md
+++ b/website/versioned_docs/version-1.0/teleop/leader-follower/bilateral-control.md
@@ -62,8 +62,8 @@ cd openarm_teleop
 
 If the CAN interfaces are omitted, the script uses the following defaults:
 
-- For `right_arm`: leader = `can0`, follower = `can1`
-- For `left_arm`: leader = `can2`, follower = `can3`
+- For `right_arm`: leader = `can0`, follower = `can2`
+- For `left_arm`: leader = `can1`, follower = `can3`
 
 ### What the Script Does
 


### PR DESCRIPTION
Update the documentation to match the script's default values.
https://github.com/enactic/openarm_teleop/blob/b8327e284de0f2edec322e6a1a4a064fd01874e5/script/launch_bilateral.sh

Fix this:
https://github.com/enactic/openarm/pull/455#discussion_r3097582882