### PR TITLE
website: use relative file links for internal doc references

### DIFF
--- a/website/docs/api-reference/can.mdx
+++ b/website/docs/api-reference/can.mdx
@@ -13,7 +13,7 @@ The [OpenArm CAN](https://github.com/enactic/openarm_can/) Library serves as the
 It abstracts CAN bus communication via utilizing Linux's SocketCAN interface, providing an API for motor control and state monitoring. The library allows extensibility for various CAN devices beyond motors.
 
 SocketCAN is Linux's implementation of the CAN (Controller Area Network) protocol stack, providing a socket-based interface for CAN communication.
-For detailed setup instructions including CAN interface configuration, library build, and verification steps, see [Setup Guide](/software/setup).
+For detailed setup instructions including CAN interface configuration, library build, and verification steps, see [Setup Guide](./setup/index.md).
 
 ## Table of Contents
 

--- a/website/docs/faq/index.md
+++ b/website/docs/faq/index.md
@@ -11,7 +11,7 @@ Please consider integrating it with another project, for more information, refer
 
 ## The motor is not working.
 
-See the [troubleshooting section](/software/setup/motor-id#trouble-shooting).
+See the [troubleshooting section](../api-reference/setup/1-motor-id.mdx#trouble-shooting).
 
 ## Do you have any recommended CAN devices?
 

--- a/website/docs/teleop/leader-follower/setup-guide.md
+++ b/website/docs/teleop/leader-follower/setup-guide.md
@@ -9,7 +9,7 @@ This guide walks you through the steps to set up and build the `openarm_teleop` 
 
 Before proceeding, please ensure the following dependencies are satisfied:
 
-- ✅ `openarm_description` library (see [OpenArm Description](/software/description))
+- ✅ `openarm_description` library (see [OpenArm Description](../../api-reference/description.mdx))
 
 ---
 

--- a/website/versioned_docs/version-1.0/faq/index.md
+++ b/website/versioned_docs/version-1.0/faq/index.md
@@ -11,11 +11,11 @@ Please consider integrating it with another project, for more information, refer
 
 ## The motor is not working.
 
-See the [troubleshooting section](/software/setup/motor-id#trouble-shooting).
+See the [troubleshooting section](../software/setup/1-motor-id.mdx#trouble-shooting).
 
 ## Do you have any recommended CAN devices?
 
-Please use the devices listed in the [Bill of Materials > Electronics](/hardware/bill-of-materials/electrical).
+Please use the devices listed in the [Bill of Materials > Electronics](../hardware/bill-of-materials/electrical.mdx).
 Using other CAN devices may result in unexpected behavior.
 
 ## How accurate and repeatable is it?

--- a/website/versioned_docs/version-1.0/hardware/assembly-guide/gripper-sub-assembly.mdx
+++ b/website/versioned_docs/version-1.0/hardware/assembly-guide/gripper-sub-assembly.mdx
@@ -10,7 +10,7 @@ import AssemblyGuideImage from '@site/src/components/AssemblyGuideImage';
 
 :::warning
 ### Prerequisites
-**Before starting** the assembly, please configure motor IDs by following [Step 1: Setup Motor ID](/software/setup/motor-id).
+**Before starting** the assembly, please configure motor IDs by following [Step 1: Setup Motor ID](../../software/setup/1-motor-id.mdx).
 :::
 
 1. Attach `J8_A` to `J8_B` using 3 `M3x6` bolts

--- a/website/versioned_docs/version-1.0/hardware/assembly-guide/j1-j2-sub-assembly.mdx
+++ b/website/versioned_docs/version-1.0/hardware/assembly-guide/j1-j2-sub-assembly.mdx
@@ -10,7 +10,7 @@ import AssemblyGuideImage from '@site/src/components/AssemblyGuideImage';
 
 :::warning
 ### Prerequisites
-**Before starting** the assembly, please configure motor IDs by following [Step 1: Setup Motor ID](/software/setup/motor-id).
+**Before starting** the assembly, please configure motor IDs by following [Step 1: Setup Motor ID](../../software/setup/1-motor-id.mdx).
 :::
 
 1. Attach the rear of the `J1` motor to `J1_A` with 5 `M4x10` bolts. Ensure the power and communication ports remain accessible. Ensure that this motor has been configured to have `ID:0x01` and `Master ID:0x11`

--- a/website/versioned_docs/version-1.0/hardware/assembly-guide/j2-j3-sub-assembly.mdx
+++ b/website/versioned_docs/version-1.0/hardware/assembly-guide/j2-j3-sub-assembly.mdx
@@ -10,7 +10,7 @@ import AssemblyGuideImage from '@site/src/components/AssemblyGuideImage';
 
 :::warning
 ### Prerequisites
-**Before starting** the assembly, please configure motor IDs by following [Step 1: Setup Motor ID](/software/setup/motor-id).
+**Before starting** the assembly, please configure motor IDs by following [Step 1: Setup Motor ID](../../software/setup/1-motor-id.mdx).
 :::
 
 1. Attach `J2_A` to `J2_B` using 2 `M4x10` bolts

--- a/website/versioned_docs/version-1.0/hardware/assembly-guide/j3-j4-sub-assembly.mdx
+++ b/website/versioned_docs/version-1.0/hardware/assembly-guide/j3-j4-sub-assembly.mdx
@@ -10,7 +10,7 @@ import AssemblyGuideImage from '@site/src/components/AssemblyGuideImage';
 
 :::warning
 ### Prerequisites
-**Before starting** the assembly, please configure motor IDs by following [Step 1: Setup Motor ID](/software/setup/motor-id).
+**Before starting** the assembly, please configure motor IDs by following [Step 1: Setup Motor ID](../../software/setup/1-motor-id.mdx).
 :::
 
 1. Attach `J4_A` to the `J3` motor using 6 `M3x6` bolts. Make sure the two Power+CAN ports face the front and rear for easy wiring.

--- a/website/versioned_docs/version-1.0/hardware/assembly-guide/j4-j5-sub-assembly.mdx
+++ b/website/versioned_docs/version-1.0/hardware/assembly-guide/j4-j5-sub-assembly.mdx
@@ -10,7 +10,7 @@ import AssemblyGuideImage from '@site/src/components/AssemblyGuideImage';
 
 :::warning
 ### Prerequisites
-**Before starting** the assembly, please configure motor IDs by following [Step 1: Setup Motor ID](/software/setup/motor-id).
+**Before starting** the assembly, please configure motor IDs by following [Step 1: Setup Motor ID](../../software/setup/1-motor-id.mdx).
 :::
 
 1. Attach `J4_C` to the rotor of `J4` motor using 6 `M3x6` bolts

--- a/website/versioned_docs/version-1.0/hardware/assembly-guide/j5-j6-j7-sub-assembly.mdx
+++ b/website/versioned_docs/version-1.0/hardware/assembly-guide/j5-j6-j7-sub-assembly.mdx
@@ -10,7 +10,7 @@ import AssemblyGuideImage from '@site/src/components/AssemblyGuideImage';
 
 :::warning
 ### Prerequisites
-**Before starting** the assembly, please configure motor IDs by following [Step 1: Setup Motor ID](/software/setup/motor-id).
+**Before starting** the assembly, please configure motor IDs by following [Step 1: Setup Motor ID](../../software/setup/1-motor-id.mdx).
 :::
 
 1. Install the `FL6700ZZ` bearing into the sheet metal component `J6_A`, and gently insert `J7_B` into the bearing, aligning it as shown in the figure.

--- a/website/versioned_docs/version-1.0/hardware/assembly-guide/leader-end-effector-sub-assembly.mdx
+++ b/website/versioned_docs/version-1.0/hardware/assembly-guide/leader-end-effector-sub-assembly.mdx
@@ -10,7 +10,7 @@ import AssemblyGuideImage from '@site/src/components/AssemblyGuideImage';
 
 :::warning
 ### Prerequisites
-**Before starting** the assembly, please configure motor IDs by following [Step 1: Setup Motor ID](/software/setup/motor-id).
+**Before starting** the assembly, please configure motor IDs by following [Step 1: Setup Motor ID](../../software/setup/1-motor-id.mdx).
 :::
 
 1. Attach `J8_A` to `J8_B` using 3 `M3x6` bolts

--- a/website/versioned_docs/version-1.0/hardware/assembly-guide/pedestal-assembly.mdx
+++ b/website/versioned_docs/version-1.0/hardware/assembly-guide/pedestal-assembly.mdx
@@ -11,7 +11,7 @@ import AssemblyGuideImage from '@site/src/components/AssemblyGuideImage';
 
 :::warning
 ### Prerequisites
-**Before starting** the assembly, please configure motor IDs by following [Step 1: Setup Motor ID](/software/setup/motor-id).
+**Before starting** the assembly, please configure motor IDs by following [Step 1: Setup Motor ID](../../software/setup/1-motor-id.mdx).
 :::
 
 1. Place the base plate on a flat surface.

--- a/website/versioned_docs/version-1.0/hardware/bill-of-materials/procuring-components.mdx
+++ b/website/versioned_docs/version-1.0/hardware/bill-of-materials/procuring-components.mdx
@@ -18,8 +18,8 @@ This section outlines how to source all required components for this project.
 
 We divide components into:
 
-- [**Off-the-shelf Components**](/hardware/bill-of-materials/arm-off-the-shelf): Standard items with a part number.
-- [**Manufactured Components**](/hardware/bill-of-materials/arm-manufactured): Machined on-demand using MISUMI’s MEVIY service.
+- [**Off-the-shelf Components**](./arm-off-the-shelf.mdx): Standard items with a part number.
+- [**Manufactured Components**](./arm-manufactured.mdx): Machined on-demand using MISUMI’s MEVIY service.
 
 All required components are listed in the Bill of Materials section, with model numbers and recommended sources.
 

--- a/website/versioned_docs/version-1.0/software/can.mdx
+++ b/website/versioned_docs/version-1.0/software/can.mdx
@@ -13,7 +13,7 @@ The [OpenArm CAN](https://github.com/enactic/openarm_can/) Library serves as the
 It abstracts CAN bus communication via utilizing Linux's SocketCAN interface, providing an API for motor control and state monitoring. The library allows extensibility for various CAN devices beyond motors.
 
 SocketCAN is Linux's implementation of the CAN (Controller Area Network) protocol stack, providing a socket-based interface for CAN communication.
-For detailed setup instructions including CAN interface configuration, library build, and verification steps, see [Setup Guide](/software/setup).
+For detailed setup instructions including CAN interface configuration, library build, and verification steps, see [Setup Guide](./setup/index.md).
 
 ## Table of Contents
 

--- a/website/versioned_docs/version-1.0/software/setup/2-can-setup.mdx
+++ b/website/versioned_docs/version-1.0/software/setup/2-can-setup.mdx
@@ -6,7 +6,7 @@ sidebar_position: 3
 # Step 2: Setup SocketCAN Interface
 
 Configure your CAN interface to communicate with the OpenArm motors. This step sets up SocketCAN on Linux to enable CAN bus communication.
-The [electrical BOM](/hardware/bill-of-materials/electrical) contains the device we are using for experiments.
+The [electrical BOM](../../hardware/bill-of-materials/electrical.mdx) contains the device we are using for experiments.
 
 ## Prerequisites
 

--- a/website/versioned_docs/version-1.0/software/setup/5-run-demo.mdx
+++ b/website/versioned_docs/version-1.0/software/setup/5-run-demo.mdx
@@ -28,7 +28,7 @@ More details for control can be found [here](../can).
 
 
 
-Connect the motors in a daisy-chain using XT30 2+2 cables. [See detailed wiring instructions →](/hardware/wiring-and-casing-guide/components)
+Connect the motors in a daisy-chain using XT30 2+2 cables. [See detailed wiring instructions →](../../hardware/wiring-and-casing-guide/0-components.mdx)
 
 The default demo uses motors 0x01, 0x02, 0x07 (DM4310) on CAN0 with CANFD. If your setup matches, run directly:
 

--- a/website/versioned_docs/version-1.0/teleop/leader-follower/setup-guide.md
+++ b/website/versioned_docs/version-1.0/teleop/leader-follower/setup-guide.md
@@ -9,7 +9,7 @@ This guide walks you through the steps to set up and build the `openarm_teleop` 
 
 Before proceeding, please ensure the following dependencies are satisfied:
 
-- ✅ `openarm_description` library (see [OpenArm Description](/software/description))
+- ✅ `openarm_description` library (see [OpenArm Description](../../software/description.mdx))
 
 ---
 


### PR DESCRIPTION
The documentation says to use the file path.

Official document:
https://docusaurus.io/docs/markdown-features/links

But since this can only be used within the same version, some URL paths remain unchanged.