### PR TITLE
website: use `<div>` instead of `<p>`

### DIFF
--- a/website/docs/hardware/openarm-2.0/general.mdx
+++ b/website/docs/hardware/openarm-2.0/general.mdx
@@ -17,10 +17,10 @@ import BlockImage from '@site/src/components/BlockImage';
 
 <div style={{padding: '20px', border: '2px solid #e1e8ed', borderRadius: '8px', textAlign: 'center'}}>
   <h3>📁 3DCAD and BOM</h3>
-  <p>
+  <div>
     3D CAD data required for manufacturing and customization,
     along with a bill of materials (BOM) containing purchasing information for each component.
-  </p>
+  </div>
   <a href="https://drive.google.com/drive/folders/1xxUdRus6mLwiBF3Q8xM0EPuFHIoYix0A" style={{
     display: 'inline-block',
     padding: '10px 20px',

--- a/website/docs/hardware/openarm-cell/general.mdx
+++ b/website/docs/hardware/openarm-cell/general.mdx
@@ -20,10 +20,10 @@ By defining not only the robot arm itself, but also all other elements that affe
 
 <div style={{padding: '20px', border: '2px solid #e1e8ed', borderRadius: '8px', textAlign: 'center'}}>
   <h3>📁 3DCAD and BOM</h3>
-  <p>
+  <div>
     3D CAD data required for manufacturing and customization,
     along with a bill of materials (BOM) containing purchasing information for each component.
-  </p>
+  </div>
   <a href="https://drive.google.com/drive/folders/1HzonRqvZ_1FZSTvcW09gT69bLr4alACN" style={{
     display: 'inline-block',
     padding: '10px 20px',

--- a/website/docs/purchase/index.mdx
+++ b/website/docs/purchase/index.mdx
@@ -201,12 +201,12 @@ Official Manufacturing Partners and Certified Manufacturers work closely with th
       color: '#374151'
     }}>
       <strong>From the Manufacturer:</strong>
-      <p style={{ marginTop: '0.5rem' }}>
+      <div style={{ marginTop: '0.5rem' }}>
         At WowRobo, we bring commercial-grade reliability and manufacturing standards to open-source robotics. With extensive experience in commercial robot production, we handle the assembly and testing of OpenArm with the same rigor applied to industrial robots.
-      </p>
-      <p style={{ marginTop: '0.5rem' }}>
+      </div>
+      <div style={{ marginTop: '0.5rem' }}>
         As the official manufacturer of the SO-ARM101, we're proud to have refined our processes even further for OpenArm, achieving an even higher level of precision, reliability, and overall build quality. Our philosophy is simple: deliver the finest craftsmanship with minimal profit, and grow together with the OpenArm project and its global community.
-      </p>
+      </div>
     </div>
     <a
       href="https://shop.wowrobo.com/products/openarm-open-source-humanoid-robot-arm-by-enactic"

--- a/website/versioned_docs/version-1.0/getting-started/index.mdx
+++ b/website/versioned_docs/version-1.0/getting-started/index.mdx
@@ -53,7 +53,7 @@ We're in continuous development and actively seeking contributors, research part
     }}>
       📦 Purchase Your OpenArm!
     </h3>
-    <p style={{
+    <div style={{
       marginTop: '1rem',
       marginBottom: '1.5rem',
       fontSize: '1rem',
@@ -62,7 +62,7 @@ We're in continuous development and actively seeking contributors, research part
     }}>
       Get your OpenArm, assembled or DIY, and join the global community!<br/>
       Browse verified and certified manufacturers worldwide.
-    </p>
+    </div>
     <a href="../purchase" style={{
       display: 'inline-block',
       padding: '10px 20px',

--- a/website/versioned_docs/version-1.0/purchase/index.mdx
+++ b/website/versioned_docs/version-1.0/purchase/index.mdx
@@ -201,12 +201,12 @@ Official Manufacturing Partners and Certified Manufacturers work closely with th
       color: '#374151'
     }}>
       <strong>From the Manufacturer:</strong>
-      <p style={{ marginTop: '0.5rem' }}>
+      <div style={{ marginTop: '0.5rem' }}>
         At WowRobo, we bring commercial-grade reliability and manufacturing standards to open-source robotics. With extensive experience in commercial robot production, we handle the assembly and testing of OpenArm with the same rigor applied to industrial robots.
-      </p>
-      <p style={{ marginTop: '0.5rem' }}>
+      </div>
+      <div style={{ marginTop: '0.5rem' }}>
         As the official manufacturer of the SO-ARM101, we're proud to have refined our processes even further for OpenArm, achieving an even higher level of precision, reliability, and overall build quality. Our philosophy is simple: deliver the finest craftsmanship with minimal profit, and grow together with the OpenArm project and its global community.
-      </p>
+      </div>
     </div>
     <a
       href="https://shop.wowrobo.com/products/openarm-open-source-humanoid-robot-arm-by-enactic"


### PR DESCRIPTION
The following warning will occur, so replace it with `<div>`.

```
$ npm run build
...
[WARNING] Docusaurus static site generation process emitted warnings for 5 paths
This is non-critical and can be disabled with DOCUSAURUS_IGNORE_SSG_WARNINGS=true
Troubleshooting guide: https://github.com/facebook/docusaurus/discussions/10580

- "/1.0/":
  - [HTML minifier diagnostic - error] No "p" element in scope but a "p" end tag seen - {"primary_spans":[{"end":13960,"start":13956}],"span_labels":[]}

- "/1.0/purchase/":
  - [HTML minifier diagnostic - error] No "p" element in scope but a "p" end tag seen - {"primary_spans":[{"end":19822,"start":19818}],"span_labels":[]}
  - [HTML minifier diagnostic - error] No "p" element in scope but a "p" end tag seen - {"primary_spans":[{"end":20215,"start":20211}],"span_labels":[]}

- "/hardware/openarm-2.0/general":
  - [HTML minifier diagnostic - error] No "p" element in scope but a "p" end tag seen - {"primary_spans":[{"end":14289,"start":14285}],"span_labels":[]}

- "/hardware/openarm-cell/general":
  - [HTML minifier diagnostic - error] No "p" element in scope but a "p" end tag seen - {"primary_spans":[{"end":14533,"start":14529}],"span_labels":[]}

- "/purchase/":
  - [HTML minifier diagnostic - error] No "p" element in scope but a "p" end tag seen - {"primary_spans":[{"end":19472,"start":19468}],"span_labels":[]}
  - [HTML minifier diagnostic - error] No "p" element in scope but a "p" end tag seen - {"primary_spans":[{"end":19865,"start":19861}],"span_labels":[]}
...
```

The display is the same even when using `<div>`.