### PR TITLE
website: Fix the 404 error for /hardware

### DIFF
--- a/website/docs/hardware/_category_.json
+++ b/website/docs/hardware/_category_.json
@@ -3,6 +3,7 @@
   "position": 3,
   "link": {
     "type": "generated-index",
+    "slug": "/hardware",
     "description": "Complete hardware documentation for OpenArm, including bill of materials, assembly guides, and troubleshooting."
   }
 }


### PR DESCRIPTION
Generate /hardware using the `slug`.