### PR TITLE
docs: fix OpenArm brand alt text and CAN CLI link label

### DIFF
--- a/website/docs/setup/openarm-setup/2-can-setup.mdx
+++ b/website/docs/setup/openarm-setup/2-can-setup.mdx
@@ -46,7 +46,7 @@ openarm-can-configure-socketcan-4-arms
 openarm-can-configure-socketcan-4-arms -fd -b 1000000 -d 5000000
 ```
 
-Alternatively, use `openarm-can-cli` to configure individual interfaces. For detailed usage, see [CAN CLI Reference ](../../api-reference/can/cli#can_configure--configure-can-interface).
+Alternatively, use `openarm-can-cli` to configure individual interfaces. For detailed usage, see [CAN CLI Reference](../../api-reference/can/cli#can_configure--configure-can-interface).
 
 ```bash
 # CAN FD at 5Mbps (recommended)

--- a/website/versioned_docs/version-1.0/hardware/specifications/general.mdx
+++ b/website/versioned_docs/version-1.0/hardware/specifications/general.mdx
@@ -10,7 +10,7 @@ import BlockImage from '@site/src/components/BlockImage';
 
 ## Key features
 
-<BlockImage src="hardware/specification/general/openarm-specs.png" alt="Openarm specs" width="110%" />
+<BlockImage src="hardware/specification/general/openarm-specs.png" alt="OpenArm specs" width="110%" />
 
 ## General Dimensions
 


### PR DESCRIPTION
## Summary
- Versioned v1.0 hardware specs image alt text: `Openarm` → `OpenArm`
- Setup doc: remove accidental trailing space in markdown link label `[CAN CLI Reference ]`

## Motivation
Brand consistency + cleaner polish match maintainers' website PR style.

## Verification
Markdown-only.

## Duplicate check
No matching open PRs.