### PR TITLE
docs: fix CONTRIBUTING grammar (share it on Issues)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Please report it to [GitHub Issues](https://github.com/enactic/openarm/issues/ne
 
 ## Did you have a feature request?
 
-Please share it to [GitHub Issues](https://github.com/enactic/openarm/issues/new?template=2-feature-request.yml)!
+Please share it on [GitHub Issues](https://github.com/enactic/openarm/issues/new?template=2-feature-request.yml)!
 
 ## Did you write a patch?
 


### PR DESCRIPTION
## Summary
`Please share it to [GitHub Issues]` → `Please share it on [GitHub Issues]`.

## Verification
Docs-only.

## Duplicate check
None.